### PR TITLE
Make servers and integrations run in parallel (threading)

### DIFF
--- a/integrations/blog.py
+++ b/integrations/blog.py
@@ -10,7 +10,7 @@ from integrations.core.base import BaseIntegration
 class BlogIntegration(BaseIntegration):
     """Integration that fetches and indexes a demo blog."""
 
-    async def load_documents(self) -> list[Document]:
+    def load_documents(self) -> list[Document]:
         loader = WebBaseLoader(
             web_paths=("https://lilianweng.github.io/posts/2023-06-23-agent/",),
             bs_kwargs={

--- a/integrations/core/base.py
+++ b/integrations/core/base.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 import hashlib
 from abc import ABC, abstractmethod
+from time import sleep
 from typing import Iterable, List
 
 from langchain_chroma import Chroma
@@ -22,7 +22,7 @@ class BaseIntegration(ABC):
 
 
     @abstractmethod
-    async def load_documents(self) -> List[Document]:
+    def load_documents(self) -> List[Document]:
         """Return a list of documents to store in the vector DB."""
         raise NotImplementedError
 
@@ -68,22 +68,22 @@ class BaseIntegration(ABC):
         self.vector_store.add_documents(chunks, ids=ids)
 
 
-    async def run(self) -> None:
+    def run(self) -> None:
         """Periodically load documents and store them."""
         while True:
             self._logger.debug(f"Running integration task: {self.__class__.__name__}")
             try:
-                docs = await self.load_documents()
+                docs = self.load_documents()
                 if docs:
-                    await self._process_documents(docs)
+                    self._process_documents(docs)
             except Exception as exc:  # pragma: no cover - log and continue
                 self._logger.error(
                     f"Integration {self.__class__.__name__} failed: {exc}"
                 )
             self._logger.debug(f"Integration task: {self.__class__.__name__} finished. It will be executed again in {self.get_interval()} seconds.")
-            await asyncio.sleep(self.get_interval())
+            sleep(self.get_interval())
 
-    async def _process_documents(self, docs: Iterable[Document]) -> None:
+    def _process_documents(self, docs: Iterable[Document]) -> None:
         new_docs: List[Document] = []
         modified_docs: List[Document] = []
 
@@ -101,12 +101,12 @@ class BaseIntegration(ABC):
                 continue
 
         if new_docs:
-            await self._handle_new_documents(new_docs)
+            self._handle_new_documents(new_docs)
 
         if modified_docs:
-            await self._handle_modified_documents(modified_docs)
+            self._handle_modified_documents(modified_docs)
 
-    async def _handle_new_documents(self, docs: List[Document]) -> None:
+    def _handle_new_documents(self, docs: List[Document]) -> None:
         for doc in docs:
             doc_id = self._doc_id(doc)
             doc_hash = self._doc_hash(doc)
@@ -114,7 +114,7 @@ class BaseIntegration(ABC):
             self._add_chunks(chunks, doc_id, doc_hash)
             self._logger.debug(f"Added {len(chunks)} chunks for new doc {doc_id}")
 
-    async def _handle_modified_documents(self, docs: List[Document]) -> None:
+    def _handle_modified_documents(self, docs: List[Document]) -> None:
         for doc in docs:
             doc_id = self._doc_id(doc)
             doc_hash = self._doc_hash(doc)

--- a/integrations/core/manager.py
+++ b/integrations/core/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import asyncio
+import os
+import threading
 from typing import Type
 
 from langchain_chroma import Chroma
@@ -17,6 +18,7 @@ class IntegrationManager:
     def __init__(self) -> None:
         self._logger = Logger.get_logger(self.__class__)
         self._integrations: dict[str, BaseIntegration] = {}
+        self._threads: list[threading.Thread] = []
 
     def register(self, integration: Type[BaseIntegration]) -> None:
 
@@ -41,7 +43,16 @@ class IntegrationManager:
         self._logger.debug("All integrations were registered successfully")
 
 
-    async def start_all(self) -> None:
+    def start_all(self) -> None:
+        """Launch all registered integrations in background threads."""
+        debug = os.environ.get("DEBUG", "false").lower() in {"1", "true", "yes"}
+
         for integration_name, integration in self._integrations.items():
-            self._logger.debug(f"Launching integration task for {integration_name}")
-            asyncio.create_task(integration.run())
+            self._logger.debug(f"Launching integration thread for {integration_name}")
+            thread = threading.Thread(
+                target=lambda integ=integration: integ.run(),
+                name=f"Integration-{integration_name}",
+                daemon=not debug,
+            )
+            thread.start()
+            self._threads.append(thread)

--- a/integrations/owasp.py
+++ b/integrations/owasp.py
@@ -9,7 +9,7 @@ from integrations.core.base import BaseIntegration
 class OWASPIntegration(BaseIntegration):
     """Integration that fetches and indexes a demo blog."""
 
-    async def load_documents(self) -> list[Document]:
+    def load_documents(self) -> list[Document]:
         # 1) Point the loader at the OWASP Top 10 URL
         url = "https://owasp.org/www-project-top-ten/"
         loader = WebBaseLoader([url])

--- a/main.py
+++ b/main.py
@@ -1,17 +1,26 @@
 import asyncio
 import os
+from threading import Thread
+from typing import Optional
 
 import uvicorn
 
 from integrations.core.manager import IntegrationManager
 from servers.api.server import APIServer
 from servers.mcp.server import MCPServer
+from servers.mcp.transport import TransportType
 from utils.logger import Logger, LoggerLevel
 
 
 class Application:
 
     def __init__(self):
+        self.debug = os.environ.get("DEBUG", "false").lower() in {"1", "true", "yes"}
+        if self.debug:
+            Logger.set_level(LoggerLevel.DEBUG)
+        else:
+            Logger.set_level(LoggerLevel.INFO)
+
         self.__logger = Logger.get_logger(self.__class__)
 
         # Printing banner
@@ -27,10 +36,12 @@ class Application:
         self.__logger.info("Starting RAG PoC Server")
 
         # API Server
-        self.api = APIServer(title="RAG API")
+        self.api_thread: Optional[Thread] = None
+        self.api: Optional[APIServer] = None
 
         # MCP Server
-        self.mcp = MCPServer()
+        self.mcp_thread: Optional[Thread] = None
+        self.mcp: Optional[MCPServer] = None
 
         # Integration Manager
         self.__logger.info("Initializing integration manager")
@@ -38,11 +49,8 @@ class Application:
         self.integration_manager.register_all()
         self.__logger.info("Integration manager initialized successfully")
 
-    async def __run_integrations(self):
-        await self.integration_manager.start_all()
-
     def run(self):
-        asyncio.run(self.__run_integrations())
+        self.integration_manager.start_all()
 
         host = "0.0.0.0"
         api_port = 5000
@@ -50,35 +58,83 @@ class Application:
 
         use_api = True
         use_mcp = True
+
         if use_api:
-            config = uvicorn.Config(self.api, host=host, port=api_port, log_config=None, reload=debug)
-            server = uvicorn.Server(config)
-            self.__logger.info("API server started successfully!")
-            self.__logger.info(f"API server running on http://{host}:{api_port}")
-            asyncio.run(server.serve())
+            self.start_api_server(api_port, host)
 
         if use_mcp:
-            self.mcp.settings.host = host
-            self.mcp.settings.port = mcp_port
+            self.start_mcp_server(host, mcp_port)
 
-            # mcp_transport_protocol = "streamable-http"
-            mcp_transport_protocol = "stdio"
-            self.__logger.info("MCP server started successfully!")
-            if mcp_transport_protocol == "stdio":
-                self.__logger.info(f"MCP server running on STDIO")
-            elif mcp_transport_protocol in ["streamable-http", "sse"]:
-                self.__logger.info(f"MCP server running on http://{host}:{mcp_port}")
+        if self.api_thread is not None and self.api_thread.is_alive():
+            self.api_thread.join()
+        if self.mcp_thread is not None and self.mcp_thread.is_alive():
+            self.mcp_thread.join()
 
-            self.mcp.run(transport=mcp_transport_protocol)
+    def start_mcp_server(self, host, mcp_port):
+        if self.mcp_thread is not None and self.mcp_thread.is_alive():
+            self.__logger.warning("MCP Server thread already started")
+            return
 
-debug = os.environ.get("DEBUG", "false").lower() in {"1", "true", "yes"}
-if debug:
-    Logger.set_level(LoggerLevel.DEBUG)
-else:
-    Logger.set_level(LoggerLevel.INFO)
+        self.__logger.info("Starting MCP Server")
+
+        self.mcp = MCPServer()
+        self.mcp.settings.host = host
+        self.mcp.settings.port = mcp_port
+        mcp_transport = TransportType.HTTP  # STDIO (local) by default
+
+        self.__logger.info("MCP Server started successfully")
+        if mcp_transport == TransportType.STDIO:
+            self.__logger.info(f"MCP server running on STDIO")
+        elif mcp_transport in [TransportType.SSE, TransportType.HTTP]:
+            self.__logger.info(f"MCP server running on http://{host}:{mcp_port}")
+
+        self.mcp_thread = Thread(
+            target=self.mcp.run,
+            kwargs={"transport": mcp_transport.value},
+            name="MCP Server",
+            daemon=not self.debug,
+        )
+        self.mcp_thread.start()
+
+    def start_api_server(self, api_port, host):
+        if self.api_thread is not None and self.api_thread.is_alive():
+            self.__logger.warning("API server thread already started")
+            return
+
+        self.__logger.info("Starting API server")
+
+        self.api = APIServer(title="RAG API")
+        config = uvicorn.Config(self.api, host=host, port=api_port, log_config=None, reload=self.debug)
+        server = uvicorn.Server(config)
+
+        self.__logger.info("API server started successfully!")
+        self.__logger.info(f"API server running on http://{host}:{api_port}")
+
+        self.api_thread = Thread(
+            target=lambda: asyncio.run(server.serve()),
+            name="API Server",
+            daemon=not self.debug,
+        )
+        self.api_thread.start()
 
 _app_instance = Application()
 app = _app_instance.api
 
+
+def monkey_patch_to_prevent_uvicorn_print_logs():
+    # 1) Get uvicorn config __init__ method
+    _original_uvicorn_config_init = uvicorn.Config.__init__
+
+    # 2) Define a wrapper that sets the log_config value
+    def _patched_uvicorn_config_init(self, *args, **kwargs):
+        # Set or override log_config value
+        kwargs["log_config"] = None
+        # Calls the original method with the log_config value set
+        _original_uvicorn_config_init(self, *args, **kwargs)
+
+    # 3) Apply the patch
+    uvicorn.Config.__init__ = _patched_uvicorn_config_init
+
+monkey_patch_to_prevent_uvicorn_print_logs()
 if __name__ == "__main__":
     _app_instance.run()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -54,6 +54,7 @@ class Logger:
     _instances           = {}
     _console_handlers     = []
     _file_handlers = []
+    level = LoggerLevel.INFO
 
     @classmethod
     def set_level(cls, lvl: LoggerLevel):
@@ -62,6 +63,7 @@ class Logger:
         """
         root = logging.getLogger()
         root.setLevel(lvl.level_no)
+        cls.level = lvl
 
         for ch in cls._console_handlers:
             ch.setLevel(lvl.level_no)
@@ -88,7 +90,7 @@ class Logger:
 
         # This prevents other libraries to override this logger configuration
         logging.basicConfig(
-            level=logging.DEBUG,
+            level=cls.level.level_no,
             format="%(asctime)s - [%(levelname)s] %(name)s - %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
             force=True,


### PR DESCRIPTION
- Move integration to be executed in independent threads to prevent blocking their execution
- Start API and MCP servers in threads to allow parallel execution of API and MCP at the same time
- Added a monkey patch to prevent a bug while running MCP server through HTTP protocol because it uses the uvicorn log config to show some logs that were duplicated and with a different format