### PR TITLE
Added integration that uses a non-real information

### DIFF
--- a/docs/integrations/Quasirelic.txt
+++ b/docs/integrations/Quasirelic.txt
@@ -1,0 +1,24 @@
+Title: A Comprehensive Study on Quasirelic Phenomena in Quantum Substrates
+
+Abstract:
+Quasirelics are hypothetical quantum entities theorized to emerge at the boundary between conventional quantum mechanics and relativistic quantum fields. First proposed within this paper, quasirelics demonstrate properties that challenge classical interpretations of entanglement, coherence, and locality.
+
+Introduction:
+In recent decades, extensive experimental observations at quantum scales have continually revealed novel phenomena. Among these phenomena, the hypothetical construct known as "quasirelics" provides intriguing theoretical implications for quantum physics. Defined as transient quantum states arising spontaneously under extreme quantum interference conditions, quasirelics serve as intermediaries between particle-like and wave-like behaviors.
+
+Theoretical Background:
+Quasirelic theory posits that under precise conditions—specifically, highly coherent quantum interference coupled with fluctuating vacuum fields—quantum systems momentarily attain an intermediate, relic-like state characterized by anomalous correlations. Unlike typical quantum states, quasirelics exhibit a pseudo-classical stability that persists briefly before dissipating into the vacuum.
+
+Properties of Quasirelics:
+1. Anomalous Quantum Stability: Quasirelics demonstrate a peculiar resilience to decoherence, lasting significantly longer than standard entangled states under similar environmental perturbations.
+2. Pseudo-Locality: While fundamentally non-local, quasirelics appear to localize spontaneously under observation, producing measurable classical-like footprints in quantum substrates.
+3. Energy Signature: Quasirelic formation is predicted to emit a distinctive low-energy radiation pattern detectable via advanced quantum spectroscopy.
+
+Experimental Predictions:
+Experimental verification of quasirelics could be approached by inducing controlled quantum interference in superconducting circuits or ultracold atomic gases. Detection methods would involve precision interferometry coupled with quantum tomography techniques, aiming to isolate anomalous stabilization phases indicative of quasirelic formation.
+
+Implications:
+Confirmation of quasirelic existence would significantly alter quantum field theory, potentially requiring modifications to standard models and interpretations of quantum mechanics. Additionally, quasirelic-based systems could offer unprecedented opportunities for quantum information storage and processing due to their resilience against decoherence.
+
+Conclusion:
+Although entirely theoretical, quasirelics present a provocative concept warranting further exploration within experimental quantum physics. Investigations into quasirelic phenomena could yield revolutionary insights into fundamental physics, fostering a new generation of quantum technological applications.

--- a/integrations/not_existing.py
+++ b/integrations/not_existing.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from langchain_community.document_loaders import TextLoader
+from langchain_core.documents import Document
+
+from integrations.core.base import BaseIntegration
+
+
+class NotExistingIntegration(BaseIntegration):
+    """Integration that fetches and indexes a demo blog."""
+
+    def load_documents(self) -> list[Document]:
+        project_root = str(Path(__file__).resolve().parents[1])
+        relative_path_list = ["docs", "integrations", "Quasirelic.txt"]
+        relative_path = os.path.sep.join(relative_path_list)
+        absolute_path = os.path.join(project_root, relative_path)
+        loader = TextLoader(file_path=absolute_path)
+
+        return loader.load()

--- a/servers/mcp/server.py
+++ b/servers/mcp/server.py
@@ -35,11 +35,11 @@ class MCPServer(FastMCP):
         )
         self.add_prompt(prompt_obj)
 
-    async def search(self, question: str, threshold: float = 0.9) -> List[Tuple[str, float]]:
+    async def search(self, question: str, similarity_distance: float = 0.9) -> List[Tuple[str, float]]:
         """
-        Retrieve relevant cybersecurity context (vulnerabilities and processes) via RAG.
+        Retrieve relevant cybersecurity context (vulnerabilities and processes) via RAG. Use similarity_distance bigger than 1.3 for more results (and also less accuracy)
         """
-        docs = self.db_service.get_query_results(question, threshold=threshold)
+        docs = self.db_service.get_query_results(question, threshold=similarity_distance)
         return [(doc.page_content, score) for doc, score in docs]
 
     @staticmethod


### PR DESCRIPTION
The goal is to verify if LLMs are able to get the information about the non-existing term "Quasirelic" (a text generated by another AI) from the MCP Server